### PR TITLE
docs: add installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,22 @@ The key binding is set by the mapping
 ```vim
     nmap dsp <Plug>(ToggleScratchPad)
 ```
+
+## Installation
+Add one of the following to your `.vimrc`, according to your plugin manager:
+
+#### Vim's built-in plugin manager (pack)
+```vim
+    mkdir -p ~/.vim/pack/plugins/start
+    git clone https://github.com/konfekt/vim-scratchpad.git ~/.vim/pack/plugins/start/vim-scratchpad
+```
+
+#### Vim Plug
+```vim
+    Plug 'konfekt/vim-scratchpad'
+```
+
+#### Vundle
+```vim
+    Plugin 'konfekt/vim-scratchpad'
+```

--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ The key binding is set by the mapping
 ## Installation
 Add one of the following to your `.vimrc`, according to your plugin manager:
 
-#### Vim's built-in plugin manager (pack)
-```vim
-    mkdir -p ~/.vim/pack/plugins/start
-    git clone https://github.com/konfekt/vim-scratchpad.git ~/.vim/pack/plugins/start/vim-scratchpad
-```
-
 #### Vim Plug
 ```vim
     Plug 'konfekt/vim-scratchpad'
@@ -40,4 +34,11 @@ Add one of the following to your `.vimrc`, according to your plugin manager:
 #### Vundle
 ```vim
     Plugin 'konfekt/vim-scratchpad'
+```
+
+...Or use vim's native plugin manager:
+#### Vim Packages
+```vim
+    mkdir -p ~/.vim/pack/plugins/start
+    git clone https://github.com/konfekt/vim-scratchpad.git ~/.vim/pack/plugins/start/vim-scratchpad
 ```


### PR DESCRIPTION
First of all, thanks a lot for building this useful plugin! I thought adding explicit installation instructions would be useful to people who might be new to vim and to the plugin ecosystem. Just a small doc improvement.